### PR TITLE
Fix a deprecation warning

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -330,10 +330,12 @@ class Theme
      */
     protected function cleanPath($path = '')
     {
-        $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+        if ($path) {
+            $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 
-        if ($path && !is_file($path)) {
-            Str::finish($path, DIRECTORY_SEPARATOR);
+            if (!is_file($path)) {
+                Str::finish($path, DIRECTORY_SEPARATOR);
+            }
         }
 
         return $path;


### PR DESCRIPTION
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

For more info, [READ HERE](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation)