### PR TITLE
error while creating theme from cli via theme:make coomand.

### DIFF
--- a/src/ThemesManager.php
+++ b/src/ThemesManager.php
@@ -64,7 +64,9 @@ class ThemesManager
             throw new ThemeNotFoundException($name);
         }
 
-        $this->current()?->disable();
+        //$this->current()?->disable(); //old
+
+        $this->current() ?  $this->disable($name) : '';
 
         $this->enable($name);
 
@@ -79,8 +81,7 @@ class ThemesManager
         return $this->themes
             ->filter(function ($theme) {
                 return $theme->enabled();
-            })->first()
-        ;
+            })->first();
     }
 
     /**
@@ -171,7 +172,8 @@ class ThemesManager
         if (Str::contains($asset, '::')) {
             $assetParts = explode('::', $asset);
 
-            return $this->findByName($assetParts[0])?->url($assetParts[1], $absolute);
+            //return $this->findByName($assetParts[0])?->url($assetParts[1], $absolute); //old
+            return $this->findByName($assetParts[0]) ? $this->url($assetParts[1], $absolute) : '';
         }
 
         // If no Theme set, return /$asset

--- a/src/ThemesManager.php
+++ b/src/ThemesManager.php
@@ -170,18 +170,7 @@ class ThemesManager
         if (Str::contains($asset, '::')) {
             $assetParts = explode('::', $asset);
 
-            /**
-             * Syntax error unexpected '->' arrow T_OBJECT_OPERATOR.
-             * this error does not allow the theme:make command to proceed after inserting 
-             * vendor name in the command line (CLI); 
-             * the code below was commented out and replaced with the new code to fix the error.
-             * dakingeorge58@gmail.com
-             * www.telegram.com/codedweb.
-             */
-
-            //return $this->findByName($assetParts[0])?->url($assetParts[1], $absolute); //old
-
-            return $this->findByName($assetParts[0]) ? $this->url($assetParts[1], $absolute) : ''; //new
+            return optional($this->findByName($assetParts[0]))->url($assetParts[1], $absolute);
         }
 
         // If no Theme set, return /$asset

--- a/src/ThemesManager.php
+++ b/src/ThemesManager.php
@@ -64,9 +64,18 @@ class ThemesManager
             throw new ThemeNotFoundException($name);
         }
 
+        /**
+         * Syntax error unexpected '->' arrow T_OBJECT_OPERATOR.
+         * this error does not allow the theme:make command to proceed after inserting 
+         * vendor name in the command line (CLI); 
+         * the code below was commented out and replaced with the new code to fix the error.
+         * dakingeorge58@gmail.com
+         * www.telegram.com/codedweb.
+         */
+
         //$this->current()?->disable(); //old
 
-        $this->current() ?  $this->disable($name) : '';
+        $this->current() ?  $this->disable($name) : ''; //new
 
         $this->enable($name);
 
@@ -172,8 +181,18 @@ class ThemesManager
         if (Str::contains($asset, '::')) {
             $assetParts = explode('::', $asset);
 
+            /**
+             * Syntax error unexpected '->' arrow T_OBJECT_OPERATOR.
+             * this error does not allow the theme:make command to proceed after inserting 
+             * vendor name in the command line (CLI); 
+             * the code below was commented out and replaced with the new code to fix the error.
+             * dakingeorge58@gmail.com
+             * www.telegram.com/codedweb.
+             */
+
             //return $this->findByName($assetParts[0])?->url($assetParts[1], $absolute); //old
-            return $this->findByName($assetParts[0]) ? $this->url($assetParts[1], $absolute) : '';
+
+            return $this->findByName($assetParts[0]) ? $this->url($assetParts[1], $absolute) : ''; //new
         }
 
         // If no Theme set, return /$asset

--- a/src/ThemesManager.php
+++ b/src/ThemesManager.php
@@ -64,18 +64,7 @@ class ThemesManager
             throw new ThemeNotFoundException($name);
         }
 
-        /**
-         * Syntax error unexpected '->' arrow T_OBJECT_OPERATOR.
-         * this error does not allow the theme:make command to proceed after inserting 
-         * vendor name in the command line (CLI); 
-         * the code below was commented out and replaced with the new code to fix the error.
-         * dakingeorge58@gmail.com
-         * www.telegram.com/codedweb.
-         */
-
-        //$this->current()?->disable(); //old
-
-        $this->current() ?  $this->disable($name) : ''; //new
+        optional($this->current())->disable();
 
         $this->enable($name);
 


### PR DESCRIPTION
During the creation of a theme using the "artisan theme:make" command, an error message is displayed in the command line that reads "Unexpected T_OBJECT_OPERATOR". This error occurs because of a syntax error in the return type of the URL method and the set method in the ThemesManager class. I have made corrections to the syntax errors by updating the code with my changes marked as "//new" and leaving the original code commented out as "//old". I have not made any changes to any other files besides the ThemesManager class. Please review and merge my pull request.