### PR TITLE
[Fix] - PageTitle component ignores withAppName="false"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+        days-before-stale: 30
+        days-before-close: 5
+        stale-issue-label: 'no-issue-activity'

--- a/src/Components/PageTitle.php
+++ b/src/Components/PageTitle.php
@@ -23,8 +23,10 @@ class PageTitle extends Component
             $title = View::getSection('title');
         }
 
-        if (! empty($title) && $withAppName) {
-            if ($invert) {
+        if (! empty($title)) {
+            if (!filter_var($withAppName, FILTER_VALIDATE_BOOLEAN)) {
+                $this->title = $title;
+            } else if ($invert) {
                 $this->title = $title . ' ' . trim(e($separator)) . ' ' . config('app.name');
             } else {
                 $this->title = config('app.name') . ' ' . trim(e($separator)) . ' ' . $title;


### PR DESCRIPTION
- `withAppName="false"` was never enforced in `PageTitle` component

I might also be wrong there, but it seems I needed to `filter_var` as `withAppName` arrives as `string`.
`$invert` might have the same issue, to confirm.